### PR TITLE
Use future-proof URLconf format.

### DIFF
--- a/django_rq/tests/urls.py
+++ b/django_rq/tests/urls.py
@@ -1,10 +1,11 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
+from django_rq.tests import views
 
-urlpatterns = patterns('',
-    (r'^django-rq/', include('django_rq.urls')),
+urlpatterns = [
+    url(r'^django-rq/', include('django_rq.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^success/$', 'django_rq.tests.views.success', name='success'),
-    url(r'^error/$', 'django_rq.tests.views.error', name='error'),
-)
+    url(r'^success/$', views.success, name='success'),
+    url(r'^error/$', views.error, name='error'),
+]

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -1,21 +1,26 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns('django_rq.views',
-    url(r'^$', 'stats', name='rq_home'),
-    url(r'^queues/(?P<queue_index>[\d]+)/$', 'jobs', name='rq_jobs'),
+from django_rq import views
+
+urlpatterns = [
+    url(r'^$',
+        views.stats, name='rq_home'),
+    url(r'^queues/(?P<queue_index>[\d]+)/$',
+        views.jobs, name='rq_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/finished/$',
-        'finished_jobs', name='rq_finished_jobs'),
+        views.finished_jobs, name='rq_finished_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/started/$',
-        'started_jobs', name='rq_started_jobs'),
+        views.started_jobs, name='rq_started_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/deferred/$',
-        'deferred_jobs', name='rq_deferred_jobs'),
-    url(r'^queues/(?P<queue_index>[\d]+)/empty/$', 'clear_queue', name='rq_clear'),
-    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$', 'job_detail',
-        name='rq_job_detail'),
+        views.deferred_jobs, name='rq_deferred_jobs'),
+    url(r'^queues/(?P<queue_index>[\d]+)/empty/$',
+        views.clear_queue, name='rq_clear'),
+    url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$',
+        views.job_detail, name='rq_job_detail'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/delete/$',
-        'delete_job', name='rq_delete_job'),
+        views.delete_job, name='rq_delete_job'),
     url(r'^queues/actions/(?P<queue_index>[\d]+)/$',
-        'actions', name='rq_actions'),
+        views.actions, name='rq_actions'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/requeue/$',
-        'requeue_job_view', name='rq_requeue_job'),
-)
+        views.requeue_job_view, name='rq_requeue_job'),
+]


### PR DESCRIPTION
This syntax is compatible with all past and, as far as the current
deprecation timeline is concerned, future versions of Django.
